### PR TITLE
周报定时发送

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,15 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**
+!**/src/test/**

--- a/.plantuml/weekly.puml
+++ b/.plantuml/weekly.puml
@@ -1,0 +1,19 @@
+@startuml
+:list issue with label "周报";
+if (issues is empty) then (yes)
+    stop
+    note left
+      可能是节假日
+    end note
+else (no)
+    :list developer;
+    if (get weekly issue by developer) then (yes)
+        :parse markdown issue to html format;
+        :archive weekly issue.(edit label from "周报" to "周报归档");
+    else (no)
+        :auto write a remind email!;
+    endif
+    :fill subject(last week MON~SUN);
+    :send email;
+end
+@enduml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # keeper
+keeper for team running!
+
+## 1. 定时周报发送
+
+1. 督促team成员发送周报，否则会发送remind邮件
+2. 简化编写成本，通过 **issue template** & **markdown** 语法，专注于周报内容本身
+3. 统一管理主题、收件人等信息
+4. 归档管理周报信息，追踪周报中的问题
+
+![weekly diagram](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/wangyuheng/keeper/master/.plantuml/weekly.puml)

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.1.7.RELEASE</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>wang.crick</groupId>
+    <artifactId>keeper</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>keeper</name>
+    <description>keeper for team running!</description>
+
+    <properties>
+        <java.version>1.8</java.version>
+        <kotlin.version>1.3.50</kotlin.version>
+        <okhttp.version>4.2.2</okhttp.version>
+        <fastjson.version>1.2.62</fastjson.version>
+        <h2.version>1.4.200</h2.version>
+        <commonmark.version>0.13.0</commonmark.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <version>${fastjson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+            <version>${commonmark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.commonmark</groupId>
+            <artifactId>commonmark-ext-gfm-tables</artifactId>
+            <version>${commonmark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <configuration>
+                    <compilerPlugins>
+                        <!-- spring @Configuration 需要class不为final, 依赖allopen -->
+                        <plugin>spring</plugin>
+                        <!-- JPA 需要一个空参数构造函数, 依赖no-arg -->
+                        <plugin>jpa</plugin>
+                    </compilerPlugins>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-allopen</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-noarg</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/kotlin/wang/crick/keeper/Application.kt
+++ b/src/main/kotlin/wang/crick/keeper/Application.kt
@@ -1,0 +1,32 @@
+package wang.crick.keeper
+
+import okhttp3.OkHttpClient
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@SpringBootApplication
+@EnableScheduling
+open class Application
+
+fun main(args: Array<String>) {
+    runApplication<Application>(*args)
+}
+
+@Component
+open class WebConfig {
+    private val timeout: Duration = Duration.ofSeconds(60)
+
+    @Bean
+    fun okHttpClient() = OkHttpClient().newBuilder()
+            .callTimeout(timeout)
+            .connectTimeout(timeout)
+            .readTimeout(timeout)
+            .writeTimeout(timeout)
+            .build()
+}
+
+

--- a/src/main/kotlin/wang/crick/keeper/client/EmailClient.kt
+++ b/src/main/kotlin/wang/crick/keeper/client/EmailClient.kt
@@ -1,0 +1,18 @@
+package wang.crick.keeper.client
+
+import org.springframework.stereotype.Component
+
+
+interface EmailClient {
+
+    fun send(subject: String, content: String, receivers: String): Boolean
+
+}
+
+@Component
+class AliyunEmailClient : EmailClient {
+    override fun send(subject: String, content: String, receivers: String): Boolean {
+        println("mock send a email to $receivers by aliyun")
+        return true
+    }
+}

--- a/src/main/kotlin/wang/crick/keeper/client/GitlabClient.kt
+++ b/src/main/kotlin/wang/crick/keeper/client/GitlabClient.kt
@@ -1,0 +1,110 @@
+package wang.crick.keeper.client
+
+import com.alibaba.fastjson.JSON
+import com.alibaba.fastjson.JSONArray
+import com.alibaba.fastjson.JSONObject
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.*
+
+const val MEDIA_TYPE_JSON = "application/json; charset=utf-8"
+const val TOKEN = "Private-Token"
+const val PAGE_SIZE = 100
+
+@Component
+class GitlabClient {
+
+    private val log: Logger = LoggerFactory.getLogger(this.javaClass)
+
+    @Value("\${gitlab.token}")
+    private lateinit var gitlabToken: String
+    @Value("\${gitlab.api}")
+    private lateinit var gitlabApi: String
+    @Autowired
+    private lateinit var okHttpClient: OkHttpClient
+
+    fun listProjectIssue(projectId: Int, params: String): List<JSONObject> {
+        val list: ArrayList<JSONObject> = ArrayList()
+        var page = 1
+        do {
+            val item = JSONArray.parseArray(this.get("$gitlabApi/projects/$projectId/issues?per_page=100&page=$page$params"), JSONObject::class.java)
+            list.addAll(item)
+            page++
+            log.info("list project issue! page -> $page size -> ${list.size} item_size -> ${item.size}")
+        } while (item.size == PAGE_SIZE)
+        return list
+    }
+
+    fun listOpenProjectIssue(projectId: Int): List<JSONObject> {
+        return listProjectIssue(projectId, "&state=opened")
+    }
+
+    fun editIssueLabels(projectId: Int, issueIid: Int, labels: String, close: Boolean) {
+        var url = "$gitlabApi/projects/$projectId/issues/$issueIid?labels=$labels"
+        if (close) {
+            url = "$url&state_event=close"
+        }
+        this.put(url, "")
+    }
+
+    fun listParticipants(projectId: Int, issueIid: Int): List<JSONObject> {
+        return JSONArray.parseArray(get("$gitlabApi/projects/$projectId/issues/$issueIid/participants"), JSONObject::class.java)
+    }
+
+    fun getGroupByName(name: String): JSONObject {
+        val response = get("$gitlabApi/groups?search=$name")
+        return JSONArray.parseArray(response, JSONObject::class.java)
+                .find { it.getString("name") == name }!!
+    }
+
+    fun getGroupDetailById(id: Int): JSONObject {
+        val response = get("$gitlabApi/groups/$id")
+        return JSON.parseObject(response)
+    }
+
+    fun listGroupProject(groupId: Int): List<JSONObject> {
+        return JSONArray.parseArray(get("$gitlabApi/groups/$groupId/projects?per_page=100"), JSONObject::class.java)
+    }
+
+
+    fun listGroupIssue(groupId: Int): List<JSONObject> {
+        val list: ArrayList<JSONObject> = ArrayList()
+
+        var page = 1
+        do {
+            val item = JSONArray.parseArray(get("$gitlabApi/groups/$groupId/issues?per_page=100&page=$page"), JSONObject::class.java)
+            list.addAll(item)
+            page++
+            log.info("listGroupIssue -> " + list.size + "item -> " + item.size)
+        } while (item.size == 100)
+
+        return list
+    }
+
+    private fun get(url: String): String {
+        val request = Request.Builder()
+                .url(url)
+                .header(TOKEN, gitlabToken)
+                .get()
+                .build()
+        return okHttpClient.newCall(request).execute().body!!.string()
+    }
+
+    private fun put(url: String, body: String): String {
+        val request = Request.Builder()
+                .url(url)
+                .header(TOKEN, gitlabToken)
+                .put(body.toRequestBody(MEDIA_TYPE_JSON.toMediaTypeOrNull()))
+                .build()
+        return okHttpClient.newCall(request).execute().body!!.string()
+    }
+
+
+}

--- a/src/main/kotlin/wang/crick/keeper/job/WeeklyJob.kt
+++ b/src/main/kotlin/wang/crick/keeper/job/WeeklyJob.kt
@@ -1,0 +1,85 @@
+package wang.crick.keeper.job
+
+import org.commonmark.ext.gfm.tables.TablesExtension
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import wang.crick.keeper.client.EmailClient
+import wang.crick.keeper.client.GitlabClient
+import wang.crick.keeper.model.Developer
+import wang.crick.keeper.model.WeeklyIssue
+import wang.crick.keeper.repository.DeveloperRepository
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+const val WEEKLY_LABEL = "周报"
+const val WEEKLY_ARCHIVE_LABEL = "周报归档"
+
+@Component
+class WeeklyJob {
+
+    private val log: Logger = LoggerFactory.getLogger(this.javaClass)
+    private val extensions = listOf(TablesExtension.create())
+    private val parser = Parser.builder()
+            .extensions(extensions)
+            .build()
+    private val renderer = HtmlRenderer.builder()
+            .extensions(extensions)
+            .build()
+
+    @Autowired
+    lateinit var gitlabClient: GitlabClient
+    @Autowired
+    lateinit var developerRepository: DeveloperRepository
+    @Autowired
+    lateinit var emailClient: EmailClient
+
+    @Value("\${weekly.projects:}")
+    private lateinit var weeklyProjectList: List<Int>
+
+    @Scheduled(cron = "\${weekly.cron}")
+    fun checkWeeklyIssue() {
+        log.info("start weekly job ! weeklyProjectList:{}", weeklyProjectList)
+        val nameMapWeeklyIssue = weeklyProjectList.flatMap {
+            gitlabClient.listOpenProjectIssue(it)
+        }.filter { issue ->
+            issue.getJSONArray("labels").contains(WEEKLY_LABEL)
+        }.filter { issue ->
+            !issue.getJSONArray("labels").contains(WEEKLY_ARCHIVE_LABEL)
+        }.map { issue ->
+            val name = issue.getJSONObject("author").getString("name")
+            name to WeeklyIssue(issue.getIntValue("project_id"), issue.getIntValue("iid"), name, issue.getString("description"))
+        }.toMap()
+        log.info("map gitlab issue data! nameMapWeeklyIssue:{}", nameMapWeeklyIssue)
+        // 如果一个记录也没有，可能是节假日导致。此时不发生提醒
+        if (nameMapWeeklyIssue.isNotEmpty()) {
+            developerRepository.findAll().forEach {
+                val weeklyIssue = nameMapWeeklyIssue[it.name]
+                this.sendEmail(weeklyIssue, it)
+            }
+        }
+    }
+
+    private fun sendEmail(weeklyIssue: WeeklyIssue?, developer: Developer) {
+        if (weeklyIssue == null) {
+            log.info("send a remind email! name:{}", developer.name)
+            emailClient.send(fillSubject(developer.name), "I am ${developer.name}. I do not write a weekly! Please remind me when you see me!", developer.receivers)
+        } else {
+            log.info("send a weekly email! name:{}", developer.name)
+            val content = renderer.render(parser.parse(weeklyIssue.description))
+            emailClient.send(fillSubject(developer.name), content, developer.receivers)
+            gitlabClient.editIssueLabels(weeklyIssue.projectId, weeklyIssue.issueId, WEEKLY_ARCHIVE_LABEL, true)
+        }
+    }
+
+    private fun fillSubject(name: String): String {
+        val lastWeek = LocalDate.now().minusWeeks(1)
+        return "[周报][XX工程][$name][${lastWeek.with(DayOfWeek.MONDAY)}~${lastWeek.with(DayOfWeek.SUNDAY)}]"
+    }
+
+}

--- a/src/main/kotlin/wang/crick/keeper/model/Developer.kt
+++ b/src/main/kotlin/wang/crick/keeper/model/Developer.kt
@@ -1,0 +1,8 @@
+package wang.crick.keeper.model
+
+import javax.persistence.Entity
+import javax.persistence.Id
+
+@Entity
+data class Developer(
+        @Id var name: String, var username: String, var email: String, var mobile: String, var receivers: String)

--- a/src/main/kotlin/wang/crick/keeper/model/WeeklyIssue.kt
+++ b/src/main/kotlin/wang/crick/keeper/model/WeeklyIssue.kt
@@ -1,0 +1,3 @@
+package wang.crick.keeper.model
+
+class WeeklyIssue(var projectId: Int, var issueId: Int, var name: String, var description: String)

--- a/src/main/kotlin/wang/crick/keeper/repository/DeveloperRepository.kt
+++ b/src/main/kotlin/wang/crick/keeper/repository/DeveloperRepository.kt
@@ -1,0 +1,6 @@
+package wang.crick.keeper.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import wang.crick.keeper.model.Developer
+
+interface DeveloperRepository : JpaRepository<Developer, String>

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,14 @@
+# gitlab
+gitlab.token=VGtzL2GXKZKSHrcFRqtz
+gitlab.api=https://gitlab.com/api/v4/
+# db
+spring.datasource.url=jdbc:h2:mem:keeper
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=root
+spring.datasource.password=123456
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=none
+# 周报issue项目
+weekly.projects=703
+weekly.cron=1 0 0 ? * SUN

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.profiles.active=dev
+spring.application.name=keeper

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,3 @@
+INSERT INTO developer (name, username, email, mobile, receivers)
+VALUES ('Zhangsan', 'zhangsan', 'zhangsan@demo.com', '18811111111', 'receiver1@demo.com,receiver2@demo.com'),
+       ('Lisi', 'lisi', 'lisi@demo.com', '18822222222', 'receiver1@demo.com');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS developer;
+
+CREATE TABLE if not exists `developer`
+(
+    `name`      varchar(128) NOT NULL COMMENT '姓名',
+    `username`  varchar(128) NOT NULL COMMENT '用户名',
+    `email`     varchar(128) NOT NULL COMMENT '邮箱',
+    `mobile`    varchar(128) NOT NULL COMMENT '手机号',
+    `receivers` text         NOT NULL COMMENT '手机号',
+    PRIMARY KEY (`name`)
+);

--- a/src/test/kotlin/wang/crick/keeper/repository/DeveloperRepositoryTest.kt
+++ b/src/test/kotlin/wang/crick/keeper/repository/DeveloperRepositoryTest.kt
@@ -1,0 +1,23 @@
+package wang.crick.keeper.repository
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.junit4.SpringRunner
+import kotlin.test.assertTrue
+
+@SpringBootTest
+@RunWith(SpringRunner::class)
+class DeveloperRepositoryTest {
+
+    @Autowired
+    private lateinit var developerRepository: DeveloperRepository
+
+    @Test
+    fun should_return_list_when_context_run() {
+        developerRepository.findAll().forEach { println(it) }
+        assertTrue(developerRepository.findAll().size > 0)
+    }
+
+}


### PR DESCRIPTION
1. 督促team成员发送周报，否则会发送remind邮件
2. 简化编写成本，通过 **issue template** & **markdown** 语法，专注于周报内容本身
3. 统一管理主题、收件人等信息
4. 归档管理周报信息，追踪周报中的问题