### PR TITLE
add dingding notify

### DIFF
--- a/.plantuml/alert.puml
+++ b/.plantuml/alert.puml
@@ -1,0 +1,10 @@
+@startuml
+gitlab -> keeper: listen event
+keeper -> keeper: resolve event msg
+alt isEmergency
+    keeper -> Dingding: send msg to group by robot
+    keeper -> gitlab: put next pipeline
+
+note left of keeper: change assignee | close issue
+end
+@enduml

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # keeper
 keeper for team running!
 
-## 1. 定时周报发送
+## feature
+
+### 1. 定时周报发送
+
+![weekly diagram](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/wangyuheng/keeper/master/.plantuml/weekly.puml)
 
 1. 督促team成员发送周报，否则会发送remind邮件
 2. 简化编写成本，通过 **issue template** & **markdown** 语法，专注于周报内容本身
 3. 统一管理主题、收件人等信息
 4. 归档管理周报信息，追踪周报中的问题
 
-![weekly diagram](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/wangyuheng/keeper/master/.plantuml/weekly.puml)
+### 2. 成员负载可视化
 
-## 2. 成员负载可视化
+![workload diagram](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/wangyuheng/keeper/master/.plantuml/workload.puml)
 
 通过图表直观展示团队成员工作负载、贡献、以及项目进度等信息
 核心目的: 细化工作量, 通过可量化、可追踪的方式, 把控项目进度
@@ -22,4 +26,24 @@ keeper for team running!
 3. 成员参与issue数量
 4. bug数量趋势
 
-![workload diagram](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/wangyuheng/keeper/master/.plantuml/workload.puml)
+### 3. Dingding消息@人
+
+![workload diagram](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/wangyuheng/keeper/master/.plantuml/alert.puml)
+
+通过图表直观展示团队成员工作负载、贡献、以及项目进度等信息
+监听`Gitlab Hook`事件, 紧急消息通过`钉钉机器人`发送至钉钉群组, 并`@(提醒)`相关方. 同时自动流转issue的`pipeline`.
+
+1. 紧急事项实时提醒到人
+2. 定制pipeline & 自动流转
+
+#### 3.1. 为什么不通过钉钉自带的gitlab机器人 或者 gitlab notify email？
+
+1. 发送的消息过多, 会忽略有意义的信息
+2. 不能 @ 到相关的人, 达不到提醒的作用
+
+
+## dependent
+
+1. [metabase](https://github.com/metabase/metabase)
+2. [dingtalk robot](https://ding-doc.dingtalk.com/doc#/serverapi2/qf2nxq)
+3. [gitlab api](https://docs.gitlab.com/ee/api/issues.html)

--- a/src/main/kotlin/wang/crick/keeper/client/DingdingClient.kt
+++ b/src/main/kotlin/wang/crick/keeper/client/DingdingClient.kt
@@ -1,0 +1,34 @@
+package wang.crick.keeper.client
+
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class DingdingClient {
+
+    val log: Logger = LoggerFactory.getLogger(this.javaClass)
+
+    @Value("\${dingding.url}")
+    private lateinit var robotUrl: String
+    @Autowired
+    private lateinit var okHttpClient: OkHttpClient
+
+    fun send(json: String): String? {
+        log.info("send msg. -> $json")
+        val request = Request.Builder()
+                .url(robotUrl)
+                .post(json.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull()))
+                .build()
+        val response = okHttpClient.newCall(request).execute().body!!.string()
+        log.info("send msg receive -> $response")
+        return response
+    }
+
+}

--- a/src/main/kotlin/wang/crick/keeper/client/GitlabClient.kt
+++ b/src/main/kotlin/wang/crick/keeper/client/GitlabClient.kt
@@ -30,6 +30,10 @@ class GitlabClient {
     @Autowired
     private lateinit var okHttpClient: OkHttpClient
 
+    fun getUser(userId: String): JSONObject {
+        return JSONObject.parseObject(get("$gitlabApi/users/$userId"))
+    }
+
     fun listProjectIssue(projectId: Int, params: String): List<JSONObject> {
         val list: ArrayList<JSONObject> = ArrayList()
         var page = 1
@@ -44,14 +48,6 @@ class GitlabClient {
 
     fun listOpenProjectIssue(projectId: Int): List<JSONObject> {
         return listProjectIssue(projectId, "&state=opened")
-    }
-
-    fun editIssueLabels(projectId: Int, issueIid: Int, labels: String, close: Boolean) {
-        var url = "$gitlabApi/projects/$projectId/issues/$issueIid?labels=$labels"
-        if (close) {
-            url = "$url&state_event=close"
-        }
-        this.put(url, "")
     }
 
     fun listParticipants(projectId: Int, issueIid: Int): List<JSONObject> {
@@ -86,6 +82,18 @@ class GitlabClient {
         } while (item.size == 100)
 
         return list
+    }
+
+    fun editIssueLabels(projectId: Int, issueIid: Int, labels: String, close: Boolean) {
+        var url = "$gitlabApi/projects/$projectId/issues/$issueIid?labels=$labels"
+        if (close) {
+            url = "$url&state_event=close"
+        }
+        this.put(url, "")
+    }
+
+    fun editAssignee(projectId: Int, issueIid: Int, authorId: Int) {
+        this.put("$gitlabApi/projects/$projectId/issues/$issueIid?assignee_ids=$authorId", "")
     }
 
     private fun get(url: String): String {

--- a/src/main/kotlin/wang/crick/keeper/hook/GitlabHookBodyHelper.kt
+++ b/src/main/kotlin/wang/crick/keeper/hook/GitlabHookBodyHelper.kt
@@ -1,0 +1,93 @@
+package wang.crick.keeper.hook
+
+import com.alibaba.fastjson.JSONObject
+import java.util.stream.Collectors
+
+class GitlabHookBodyHelper {
+
+    companion object {
+        const val LABEL_TODO = "To Do"
+        const val LABEL_DOING = "Doing"
+        const val LABEL_VERIFY = "verify"
+        const val LABEL_P0 = "P0"
+        const val LABEL_BUG = "bug"
+        /**
+         * issue 是否已关闭
+         */
+        fun isClose(body: JSONObject): Boolean {
+            return "closed" == body.getJSONObject("object_attributes").getString("state")
+        }
+
+        fun getChangedAssignee(body: JSONObject): Assignee? {
+            return if (null == body.getJSONObject("changes")?.getJSONObject("assignees")?.getJSONArray("current")) {
+                null
+            } else {
+                val current: Map<String, String>? = body.getJSONObject("changes")?.getJSONObject("assignees")?.getJSONArray("current")?.get(0) as LinkedHashMap<String, String>
+                if (current == null) {
+                    null
+                } else {
+                    JSONObject.parseObject(JSONObject.toJSONString(current), Assignee::class.java)
+                }
+            }
+        }
+
+        fun getAuthor(body: JSONObject): String? {
+            var author: String? = null
+            val list = body.getJSONObject("object_attributes").getString("description").split("Author:")
+            if (list.size > 1) {
+                val tmp = list[1].trim().replace("@", "")
+                author = tmp.split(" ")[0]
+            }
+            return author
+        }
+
+        fun getAuthorId(body: JSONObject): String {
+            return body.getJSONObject("object_attributes").getString("author_id")
+        }
+
+        fun getIssueUrl(body: JSONObject): String {
+            return body.getJSONObject("object_attributes").getString("url")
+        }
+
+        fun getIssueTitle(body: JSONObject): String {
+            return body.getJSONObject("object_attributes").getString("title")
+        }
+
+        fun listLabelTitle(body: JSONObject): MutableSet<String> {
+            val labels = body.getJSONArray("labels")
+            return labels.stream()
+                    .map { JSONObject.toJSONString(it) }
+                    .map { JSONObject.parseObject(it) }
+                    .map { it.getString("title") }
+                    .collect(Collectors.toSet())
+        }
+
+        fun isFirstChangeToVerifyLabel(body: JSONObject): Boolean {
+            var toggle = false
+            if (body.getJSONObject("changes").containsKey("labels")) {
+                val previous = body.getJSONObject("changes").getJSONObject("labels").getJSONArray("previous")
+                        .stream()
+                        .map { label -> JSONObject.parseObject(JSONObject.toJSONString(label)).getString("title") }
+                        .collect(Collectors.toSet())
+                val current = body.getJSONObject("changes").getJSONObject("labels").getJSONArray("current")
+                        .stream()
+                        .map { label -> JSONObject.parseObject(JSONObject.toJSONString(label)).getString("title") }
+                        .collect(Collectors.toSet())
+
+                toggle = !previous.contains(LABEL_VERIFY) && current.contains(LABEL_VERIFY)
+            }
+            return toggle
+        }
+    }
+
+    class Assignee {
+        var name: String? = null
+        var username: String? = null
+
+        override fun toString(): String {
+            return "Assignee(name=$name, username=$username)"
+        }
+
+    }
+
+}

--- a/src/main/kotlin/wang/crick/keeper/hook/GitlabListener.kt
+++ b/src/main/kotlin/wang/crick/keeper/hook/GitlabListener.kt
@@ -1,0 +1,183 @@
+package wang.crick.keeper.hook
+
+import com.alibaba.fastjson.JSONObject
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import wang.crick.keeper.client.DingdingClient
+import wang.crick.keeper.client.GitlabClient
+import wang.crick.keeper.hook.GitlabHookBodyHelper.Companion.getChangedAssignee
+import wang.crick.keeper.repository.DeveloperRepository
+
+@RestController
+@RequestMapping("listener")
+class IssueListener {
+
+    val log: Logger = LoggerFactory.getLogger(this.javaClass)
+
+    @Autowired
+    private lateinit var dingdingClient: DingdingClient
+    @Autowired
+    private lateinit var gitlabClient: GitlabClient
+    @Autowired
+    private lateinit var developerRepository: DeveloperRepository
+
+    @Value("\${listen.projects:}")
+    private lateinit var listenProjectList: List<String>
+
+    @RequestMapping("/{project}")
+    fun dispatcher(@RequestBody(required = false) body: JSONObject?, @PathVariable("project") project: String): String {
+        log.info("receive project: $project body: $body")
+
+        if (listenProjectList.contains(project)) {
+            dispatcherEvent(body)
+        }
+
+        return "success"
+    }
+
+    private fun dispatcherEvent(body: JSONObject?) {
+        when (body?.getString("event_type")) {
+            "merge_request" -> handlerMr(body)
+            "issue" -> handlerIssue(body)
+        }
+    }
+
+    /**
+     * 暂不针对MergeRequest做消息提醒
+     */
+    private fun handlerMr(body: JSONObject) {
+        //TODO
+    }
+
+    private fun handlerIssue(body: JSONObject) {
+        if (GitlabHookBodyHelper.isClose(body)) {
+            //已关闭的issue不做处理
+            return
+        }
+        val changedAssignee: GitlabHookBodyHelper.Assignee? = getChangedAssignee(body)
+        log.info("handler issue changedAssignee: $changedAssignee")
+        val labelTitles: MutableSet<String> = GitlabHookBodyHelper.listLabelTitle(body)
+        log.info("handler issue labels: $labelTitles")
+        // 是否变更assignee
+        if (changedAssignee != null) {
+            val developer = developerRepository.findByUsername(changedAssignee.username!!)
+            // 为开发人员 && label为todo且不在进行中
+            if (developer != null && labelTitles.isTodo() && !labelTitles.isProcessing()) {
+                when {
+                    labelTitles.isBug() -> sendBugMsg(body, developer.mobile)
+                    labelTitles.isP0() -> sendEmergencyMsg(body, developer.mobile)
+                    else -> log.info("ignore issue change! labelTitles -> $labelTitles")
+                }
+            }
+        } else {
+            if (GitlabHookBodyHelper.isFirstChangeToVerifyLabel(body)) {
+                val author = getAuthor(body)
+                val assigneeUsername = editAssignee(body, author)
+                val mobile = developerRepository.findByUsername(assigneeUsername)?.mobile
+                if (null != mobile) {
+                    sendVerifyMsg(body, author, mobile)
+                }
+            }
+        }
+    }
+
+    /**
+     * 获取author
+     *  如果未按照模板制定，默认获取issue的创建者
+     */
+    private fun getAuthor(body: JSONObject): String {
+        val author: String? = GitlabHookBodyHelper.getAuthor(body)
+        return if (author == null) {
+            val userId = GitlabHookBodyHelper.getAuthorId(body)
+            gitlabClient.getUser(userId).getString("name")
+        } else {
+            author
+        }
+    }
+
+    private fun Set<String>.isTodo(): Boolean {
+        return this.contains(GitlabHookBodyHelper.LABEL_TODO)
+    }
+
+    private fun Set<String>.isProcessing(): Boolean {
+        return this.contains(GitlabHookBodyHelper.LABEL_VERIFY)
+                || this.contains(GitlabHookBodyHelper.LABEL_DOING)
+    }
+
+    private fun Set<String>.isBug(): Boolean {
+        return this.contains(GitlabHookBodyHelper.LABEL_BUG)
+    }
+
+    private fun Set<String>.isP0(): Boolean {
+        return this.contains(GitlabHookBodyHelper.LABEL_P0)
+    }
+
+    private fun sendEmergencyMsg(body: JSONObject, mobile: String) {
+        val author = getAuthor(body)
+        val url = GitlabHookBodyHelper.getIssueUrl(body)
+        val title = GitlabHookBodyHelper.getIssueTitle(body)
+        val msg = buildTextMsg("$author 创建了一个 [P0 issue] 给你，请尽快确认并处理 \n Link -> $url \n title -> $title ", mobile)
+        dingdingClient.send(msg)
+    }
+
+    private fun sendBugMsg(body: JSONObject, mobile: String) {
+        val author = getAuthor(body)
+        val url = GitlabHookBodyHelper.getIssueUrl(body)
+        val title = GitlabHookBodyHelper.getIssueTitle(body)
+        val msg = buildTextMsg("$author 创建了一个 [bug] 给你，请尽快确认并处理 \n Link -> $url \n title -> $title ", mobile)
+        dingdingClient.send(msg)
+    }
+
+    private fun sendVerifyMsg(body: JSONObject, author: String, mobile: String) {
+        val url = GitlabHookBodyHelper.getIssueUrl(body)
+        val title = GitlabHookBodyHelper.getIssueTitle(body)
+        val msg = buildTextMsg("Hi, $author 您有一个issue已被解决需要验证，请尽快处理并关闭 \n Link -> $url \n title -> $title ", mobile)
+        dingdingClient.send(msg)
+    }
+
+    private fun editAssignee(body: JSONObject, author: String): String {
+        val projectId = getProjectId(body)
+        val issueIid = getIssueIid(body)
+        val assigneeId = getAssigneeId(body)
+
+        val participants = gitlabClient.listParticipants(projectId, issueIid)
+
+        val authorId = participants.stream()
+                .filter { participant -> participant.getString("username") == author || participant.getString("name") == author }
+                .map { participant -> participant.getIntValue("id") }
+                .findAny().orElse(assigneeId)
+
+        if (authorId != assigneeId) {
+            gitlabClient.editAssignee(projectId, issueIid, authorId)
+        }
+
+        return participants.stream()
+                .filter { participant -> participant.getIntValue("id") == authorId }
+                .map { participant -> participant.getString("username") }
+                .findAny().orElseThrow { RuntimeException("$authorId not found!") }
+
+    }
+
+    private fun getProjectId(body: JSONObject): Int {
+        return body.getJSONObject("object_attributes").getIntValue("project_id")
+    }
+
+    private fun getIssueIid(body: JSONObject): Int {
+        return body.getJSONObject("object_attributes").getIntValue("iid")
+    }
+
+    private fun getAssigneeId(body: JSONObject): Int {
+        return body.getJSONObject("object_attributes").getIntValue("assignee_id")
+    }
+
+    private fun buildTextMsg(content: String, mobile: String): String {
+        return "{ \"msgtype\": \"text\", \"text\": { \"content\": \"$content\n@$mobile\" }, \"at\": { \"atMobiles\": [ \"$mobile\" ], \"isAtAll\": false } }"
+    }
+
+}

--- a/src/main/kotlin/wang/crick/keeper/repository/DeveloperRepository.kt
+++ b/src/main/kotlin/wang/crick/keeper/repository/DeveloperRepository.kt
@@ -3,4 +3,6 @@ package wang.crick.keeper.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import wang.crick.keeper.model.Developer
 
-interface DeveloperRepository : JpaRepository<Developer, String>
+interface DeveloperRepository : JpaRepository<Developer, String> {
+    fun findByUsername(username: String): Developer?
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,5 +1,5 @@
 # gitlab
-gitlab.token=VGtzL2GXKZKSHrcFRqtz
+gitlab.token=VGtzL2GXKZKSHrcFRqtzasx
 gitlab.api=https://gitlab.com/api/v4/
 # db
 spring.datasource.url=jdbc:h2:mem:keeper
@@ -15,3 +15,6 @@ weekly.cron=1 0 0 ? * SUN
 # 工作负载
 workload.groups=7044374
 workload.cron=0 0/30 * * * ?
+# 消息通知
+listen.projects=703
+dingding.url=

--- a/src/main/resources/metabase.sql
+++ b/src/main/resources/metabase.sql
@@ -37,7 +37,7 @@ GROUP BY progress
 # 按milestone统计bug数量
 SELECT milestone->> '$.title' as '里程碑', count(*) AS `count`
 FROM `issue`
-WHERE (lower(`issue`.`labels`) like '%bug%') and `issue`.`project_name` in('issues', 'da') and milestone->> '$.title' is not null
+WHERE (lower(`issue`.`labels`) like '%bug%') and milestone->> '$.title' is not null
   and milestone->> '$.title' <> 'sword'
 GROUP BY 里程碑;
 
@@ -48,8 +48,7 @@ SELECT  count(*) AS `count`,milestone->> '$.title', date_format(`issue`.`created
             ELSE "新增"
             END as 'plan'
 FROM `issue`
-WHERE `issue`.`project_name` = 'da'
-and milestone->> '$.title'= date_format(now(), '%Y%m')
+WHERE milestone->> '$.title'= date_format(now(), '%Y%m')
   and `issue`.`labels` not like '%bug%'
   and `issue`.`labels` like '%P%'
 GROUP BY plan


### PR DESCRIPTION
通过图表直观展示团队成员工作负载、贡献、以及项目进度等信息
监听`Gitlab Hook`事件, 紧急消息通过`钉钉机器人`发送至钉钉群组, 并`@(提醒)`相关方. 同时自动流转issue的`pipeline`.
